### PR TITLE
Add image.tag to updateJob and apiService values

### DIFF
--- a/charts/overpass-api-chart/templates/deployment.yaml
+++ b/charts/overpass-api-chart/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           echo "Init job completed"
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.apiService.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.apiService.image.repository }}:{{ .Values.apiService.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.apiService.image.pullPolicy }}
           env:
           - name: OVERPASS_MODE

--- a/charts/overpass-api-chart/templates/init_job.yaml
+++ b/charts/overpass-api-chart/templates/init_job.yaml
@@ -32,7 +32,7 @@ spec:
           echo "PVC is bound"
       containers:
       - name: overpass-init
-        image: "{{ .Values.updateJob.image.repository }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.updateJob.image.repository }}:{{ .Values.updateJob.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.updateJob.image.pullPolicy }}
         command:
         - /bin/sh

--- a/charts/overpass-api-chart/templates/update_job.yaml
+++ b/charts/overpass-api-chart/templates/update_job.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: overpass-update
-            image: "{{ .Values.updateJob.image.repository }}:{{ .Chart.AppVersion }}"
+            image: "{{ .Values.updateJob.image.repository }}:{{ .Values.updateJob.image.tag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.updateJob.image.pullPolicy }}
             env:
             - name: OVERPASS_MODE

--- a/charts/overpass-api-chart/values.yaml
+++ b/charts/overpass-api-chart/values.yaml
@@ -41,6 +41,8 @@ updateJob:
   image:
     repository: remikalbe/overpass-api-kube
     pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
   planetUrl: "https://planet.openstreetmap.org/planet/planet-latest.osm.bz2"
   # URL to download the initial OSM planet file
   # Explanation:
@@ -128,6 +130,8 @@ apiService:
   image:
     repository: remikalbe/overpass-api-kube
     pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
   service:
     type: ClusterIP
     port: 80


### PR DESCRIPTION
Enable users to change the container image tag used in Jobs and api service.

This PR adds `updateJob.image.tag` and `apiService.image.tag` values to allow chart users to change the container image tag used in the init and update Job and the apiService Deployment. 